### PR TITLE
Just one sentence about prioritization

### DIFF
--- a/draft-taps-quic-mapping.md
+++ b/draft-taps-quic-mapping.md
@@ -96,6 +96,8 @@ CloseGroup:
 AbortGroup:
 : Calling `AbortGroup` on any QUIC stream in a Connection Group indicates that the shared QUIC connection should be closed immediately using a CONNECTION_CLOSE frame.
 
+In addition to the API mappings described above, when there are multiple Connection objects assigned to the same QUIC connection, this mapping can support the `connPriority` Connection property.
+
 # Security Considerations
 
 The security properties of a QUIC connection are expressed in the QUIC handshake, and thus are shared

--- a/draft-taps-quic-mapping.md
+++ b/draft-taps-quic-mapping.md
@@ -96,7 +96,7 @@ CloseGroup:
 AbortGroup:
 : Calling `AbortGroup` on any QUIC stream in a Connection Group indicates that the shared QUIC connection should be closed immediately using a CONNECTION_CLOSE frame.
 
-In addition to the API mappings described above, when there are multiple Connection objects assigned to the same QUIC connection, this mapping can support the `connPriority` Connection property.
+In addition to the API mappings described above, when there are multiple Connection objects assigned to the same QUIC connection, this mapping supports the `connPriority` Connection property.
 
 # Security Considerations
 


### PR DESCRIPTION
Closes #3 

I decided to keep this simple: also, in the -impl draft, we don't discuss each and every Connection or Message Property, and it doesn't seem useful to do. Prioritization is worth mentioning though.